### PR TITLE
Fix wrong behavior of JobRepository with empty identifying job parameters

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -110,7 +110,7 @@ public class SimpleJobRepository extends SimpleJobExplorer implements JobReposit
 							+ "The last execution ended with a failure that could not be rolled back, "
 							+ "so it may be dangerous to proceed. Manual intervention is probably necessary.");
 				}
-				if ((status == BatchStatus.COMPLETED || status == BatchStatus.ABANDONED)) {
+				if (status == BatchStatus.COMPLETED || status == BatchStatus.ABANDONED) {
 					JobParameters identifyingJobParameters = new JobParameters(execution.getJobParameters().getIdentifyingParameters());
 					throw new JobInstanceAlreadyCompleteException(
 							"A job instance already exists and is complete for identifying parameters="

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/repository/support/SimpleJobRepository.java
@@ -54,6 +54,7 @@ import java.util.List;
  * @author Baris Cubukcuoglu
  * @author Parikshit Dutta
  * @author Mark John Moreno
+ * @author Seungyong Hong
  * @see JobRepository
  * @see JobInstanceDao
  * @see JobExecutionDao
@@ -109,10 +110,8 @@ public class SimpleJobRepository extends SimpleJobExplorer implements JobReposit
 							+ "The last execution ended with a failure that could not be rolled back, "
 							+ "so it may be dangerous to proceed. Manual intervention is probably necessary.");
 				}
-				JobParameters allJobParameters = execution.getJobParameters();
-				JobParameters identifyingJobParameters = new JobParameters(allJobParameters.getIdentifyingParameters());
-				if (!identifyingJobParameters.isEmpty()
-						&& (status == BatchStatus.COMPLETED || status == BatchStatus.ABANDONED)) {
+				if ((status == BatchStatus.COMPLETED || status == BatchStatus.ABANDONED)) {
+					JobParameters identifyingJobParameters = new JobParameters(execution.getJobParameters().getIdentifyingParameters());
 					throw new JobInstanceAlreadyCompleteException(
 							"A job instance already exists and is complete for identifying parameters="
 									+ identifyingJobParameters + ".  If you want to run this job again, "

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/repository/support/SimpleJobRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.JobInstance;
@@ -61,6 +63,7 @@ import org.springframework.batch.core.step.StepSupport;
  * @author Baris Cubukcuoglu
  * @author Mahmoud Ben Hassine
  * @author Parikshit Dutta
+ * @author Seungyong Hong
  *
  */
 class SimpleJobRepositoryTests {
@@ -103,7 +106,7 @@ class SimpleJobRepositoryTests {
 
 		jobRepository = new SimpleJobRepository(jobInstanceDao, jobExecutionDao, stepExecutionDao, ecDao);
 
-		jobParameters = new JobParametersBuilder().addString("bar", "test").toJobParameters();
+		jobParameters = new JobParametersBuilder().addString("bar", "test", false).toJobParameters();
 
 		job = new JobSupport();
 		job.setBeanName("RepositoryTest");
@@ -289,9 +292,10 @@ class SimpleJobRepositoryTests {
 		assertThrows(JobRestartException.class, () -> jobRepository.createJobExecution("foo", new JobParameters()));
 	}
 
-	@Test
-	void testCreateJobExecutionAlreadyComplete() {
-		jobExecution.setStatus(BatchStatus.COMPLETED);
+	@ParameterizedTest
+	@EnumSource(mode = EnumSource.Mode.INCLUDE, names = {"COMPLETED", "ABANDONED"})
+	void testCreateJobExecutionAlreadyComplete(BatchStatus batchStatus) {
+		jobExecution.setStatus(batchStatus);
 		jobExecution.setEndTime(LocalDateTime.now());
 
 		when(jobInstanceDao.getJobInstance("foo", new JobParameters())).thenReturn(jobInstance);


### PR DESCRIPTION
[이슈 내용]
Spring Batch에서는 기본적으로 성공적으로 끝난 Job에 대해서 는 같은 Job Parameters로 재실행할 수 없고 JobInstanceAlreadyCompleteException이 발생합니다.
하지만, 식별자로 사용되는 Job Parameters가 없다면 예외가 발생하지 않고 정상적으로 실행됩니다.

[수정 내용]
- 필요없이 확인되는 식별자로 사용되는 Job Parameters 확인 부분을 삭제하고, TC를 수정하였습니다.

이슈: https://github.com/spring-projects/spring-batch/issues/4755